### PR TITLE
Highlight switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changes
 
-## 0.2.1 - Switches
+## 0.2.1 - Switches and Other Infrastructure.
 
 * Highlight function and procedure switches, *e.g.*, `MESSAGE, 'Hello!', /INFORMATIONAL`.
+* Start adding snippets.
+* Add spec tests.
 
-## 0.2.0 - Deprecated directory.
+## 0.2.0 - Deprecated Directory
 
 * Store package settings in `settings/` instead of `scoped-properties/`.
 * Update package.json file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changes
 
-## 0.2.1 - Switches and Other Infrastructure.
+## 0.3.0 - Switches and Other Infrastructure.
 
 * Highlight function and procedure switches, *e.g.*, `MESSAGE, 'Hello!', /INFORMATIONAL`.
 * Start adding snippets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 0.2.1 - Switches
+
+* Highlight function and procedure switches, *e.g.*, `MESSAGE, 'Hello!', /INFORMATIONAL`.
+
 ## 0.2.0 - Deprecated directory.
 
 * Store package settings in `settings/` instead of `scoped-properties/`.

--- a/grammars/idl.json
+++ b/grammars/idl.json
@@ -62,6 +62,11 @@
             "name": "string.quoted.double.idl"
         },
         {
+            "comment": "IDL switches (e.g. /switch) set a keyword without giving it a specific value, though the value is supposed to evaluate as True.",
+            "match": "(?:,)\\s*/\\w+\\b",
+            "name": "meta.keyword.idl"
+        },
+        {
             "include": "#functions"
         },
         {

--- a/grammars/idl.json
+++ b/grammars/idl.json
@@ -63,8 +63,15 @@
         },
         {
             "comment": "IDL switches (e.g. /switch) set a keyword without giving it a specific value, though the value is supposed to evaluate as True.",
-            "match": "(?:,)\\s*/\\w+\\b",
-            "name": "meta.keyword.idl"
+            "begin": "\\b(,)\\s*(/)",
+            "beginCaptures": {
+                "1": {"name": "punctuation.separator.parameters.idl"},
+                "2": {"name": "keyword.operator.idl"}
+            },
+            "end": "(\\w+)\\b",
+            "endCaptures": {
+                "1": {"name": "variable.parmameter.function"}
+            }
         },
         {
             "include": "#functions"

--- a/grammars/idl.json
+++ b/grammars/idl.json
@@ -23,7 +23,7 @@
         },
         {
             "comment": "Labels, as in the destination of GOTO, fail.",
-            "match": "^\\s*\\S+(?=:)",
+            "match": "^\\s*\\w+(?=:)",
             "name": "entity.name.tag.idl"
         },
         {
@@ -32,14 +32,29 @@
             "name": "keyword.control.idl"
         },
         {
-            "comment": "These are the 'text' operators in IDL.",
-            "match": "\\b(?i:and|eq|ge|gt|le|lt|mod|ne|not|or|xor)=?\\b",
-            "name": "keyword.operator.idl"
+            "comment": "These are the bitwise operators in IDL (MOD is not bitwise, but we'll throw it in here).",
+            "match": "\\b(?i:and|mod|not|xor)=?\\b",
+            "name": "keyword.operator.arithmetic.idl"
+        },
+        {
+            "comment": "These are the bitwise operators in IDL (MOD is not bitwise, but we'll throw it in here).",
+            "match": "\\b(?i:and|mod|not|xor)=?\\b",
+            "name": "keyword.operator.arithmetic.idl"
+        },
+        {
+            "comment": "Basic arithmetic operators.",
+            "match": "\\+|\\-|\\*|/|\\^",
+            "name": "keyword.operator.arithmetic.idl"
+        },
+        {
+            "comment": "These are the comparison operators in IDL.",
+            "match": "\\b(?i:eq|ge|gt|le|lt|ne)\\b",
+            "name": "keyword.operator.comparison.idl"
         },
         {
             "comment": "Logical operators",
-            "match": "(?:~|&&|\\|\\|)",
-            "name": "keyword.operator.idl"
+            "match": "\\b(?:~|&&|\\|\\|)\\b",
+            "name": "keyword.operator.logical.idl"
         },
         {
             "comment": "The system variables.  Some are read-only, some are not & they can be created on the fly.",
@@ -63,14 +78,11 @@
         },
         {
             "comment": "IDL switches (e.g. /switch) set a keyword without giving it a specific value, though the value is supposed to evaluate as True.",
-            "begin": "\\b(,)\\s*(/)",
-            "beginCaptures": {
+            "match": "(^|,)\\s*(/)(\\w+)\\b",
+            "captures": {
                 "1": {"name": "punctuation.separator.parameters.idl"},
-                "2": {"name": "keyword.operator.idl"}
-            },
-            "end": "(\\w+)\\b",
-            "endCaptures": {
-                "1": {"name": "variable.parmameter.function"}
+                "2": {"name": "keyword.operator.assignment.idl"},
+                "3": {"name": "variable.parameter.function.idl"}
             }
         },
         {

--- a/snippets/language-idl.cson
+++ b/snippets/language-idl.cson
@@ -1,0 +1,4 @@
+'.source.idl':
+  'keyword_set …':
+    'prefix': 'keyword_set'
+    'body': 'KEYWORD_SET(${1:keyword})'

--- a/spec/idl-spec.coffee
+++ b/spec/idl-spec.coffee
@@ -11,3 +11,55 @@ describe 'IDL grammar', ->
     it 'parses the grammar', ->
         expect(grammar).toBeTruthy()
         expect(grammar.scopeName).toBe 'source.idl'
+
+    it 'tokenizes inline comments', ->
+        tokens = grammar.tokenizeLines 'foo = bar ; comment'
+
+        expect(tokens[0][0].value).toBe 'foo = bar '
+        expect(tokens[0][1].value).toBe ';'
+        expect(tokens[0][1].scopes).toEqual ['source.idl', 'comment.line.semicolon.idl', 'punctuation.definition.comment.idl']
+        expect(tokens[0][2].value).toBe ' comment'
+        expect(tokens[0][2].scopes).toEqual ['source.idl', 'comment.line.semicolon.idl']
+
+    it 'tokenizes leading comments', ->
+        tokens = grammar.tokenizeLines ';\n; this is a comment\n;\n'
+
+        expect(tokens[0][0].value).toBe ';'
+        expect(tokens[0][0].scopes).toEqual ['source.idl', 'comment.line.semicolon.idl', 'punctuation.definition.comment.idl']
+        expect(tokens[1][0].value).toBe ';'
+        expect(tokens[1][0].scopes).toEqual ['source.idl', 'comment.line.semicolon.idl', 'punctuation.definition.comment.idl']
+        expect(tokens[2][0].value).toBe ';'
+        expect(tokens[2][0].scopes).toEqual ['source.idl', 'comment.line.semicolon.idl', 'punctuation.definition.comment.idl']
+
+    it 'tokenizes command labels', ->
+        tokens = grammar.tokenizeLines 'fail:'
+
+        expect(tokens[0][0].value).toBe 'fail'
+        expect(tokens[0][0].scopes).toEqual ['source.idl', 'entity.name.tag.idl']
+        expect(tokens[0][1].value).toBe ':'
+        expect(tokens[0][1].scopes).toEqual ['source.idl']
+
+    it 'tokenizes keyword switches', ->
+        tokens = grammar.tokenizeLines 'foo = bar(a,b,c,d,/baz)'
+
+        expect(tokens[0][0].value).toBe 'foo = bar(a,b,c,d'
+        expect(tokens[0][0].scopes).toEqual ['source.idl']
+        expect(tokens[0][1].value).toBe ','
+        expect(tokens[0][1].scopes).toEqual ['source.idl', 'punctuation.separator.parameters.idl']
+        expect(tokens[0][2].value).toBe '/'
+        expect(tokens[0][2].scopes).toEqual ['source.idl', 'keyword.operator.assignment.idl']
+        expect(tokens[0][3].value).toBe 'baz'
+        expect(tokens[0][3].scopes).toEqual ['source.idl', 'variable.parameter.function.idl']
+        expect(tokens[0][4].value).toBe ')'
+        expect(tokens[0][4].scopes).toEqual ['source.idl']
+
+    it 'tokenizes keyword switches on multiple lines', ->
+        tokens = grammar.tokenizeLines 'foo = bar(a,b,c,d, $\n          /baz)'
+
+        expect(tokens[0][0].value).toBe 'foo = bar(a,b,c,d, $'
+        expect(tokens[1][0].value).toBe '          '
+        expect(tokens[1][1].value).toBe '/'
+        expect(tokens[1][1].scopes).toEqual ['source.idl', 'keyword.operator.assignment.idl']
+        expect(tokens[1][2].value).toBe 'baz'
+        expect(tokens[1][2].scopes).toEqual ['source.idl', 'variable.parameter.function.idl']
+        expect(tokens[1][3].value).toBe ')'

--- a/spec/idl-spec.coffee
+++ b/spec/idl-spec.coffee
@@ -1,0 +1,13 @@
+describe 'IDL grammar', ->
+    grammar = null
+
+    beforeEach ->
+        waitsForPromise ->
+            atom.packages.activatePackage 'language-idl'
+
+        runs ->
+            grammar = atom.grammars.grammarForScopeName 'source.idl'
+
+    it 'parses the grammar', ->
+        expect(grammar).toBeTruthy()
+        expect(grammar.scopeName).toBe 'source.idl'


### PR DESCRIPTION
This PR adds support for highlighting keyword switches, _e.g._ `foo(a,b,/switch)`.  It also adds some tests and snippets.

Fixes #2.
